### PR TITLE
Bump version to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-accessible-treeview",
   "description": "A react component that implements the treeview pattern as described by the WAI-ARIA Authoring Practices.",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "lissitz (https://github.com/lissitz)",
   "main": "dist/react-accessible-treeview.cjs.js",
   "module": "dist/react-accessible-treeview.esm.js",


### PR DESCRIPTION
So the last commit (https://github.com/lissitz/react-accessible-treeview/commit/d57ae3187a9ce60bd6c11ce41cd45e98ea8448c1) will reflect on NPM.