### PR TITLE
 Allow consumers to indicate if the TreeView will be using checkboxes or not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-accessible-treeview",
       "version": "2.1.4",
       "license": "MIT",
       "devDependencies": {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -626,7 +626,14 @@ export interface ITreeViewOnExpandProps {
   treeState: ITreeViewState;
 }
 
-type NodeAction = "check" | "select";
+const nodeActions = {
+  check: "check",
+  select: "select",
+} as const;
+
+export const NODE_ACTIONS = Object.freeze(Object.values(nodeActions));
+
+export type NodeAction = ValueOf<typeof nodeActions>;
 
 export interface ITreeViewProps {
   /** Tree data*/
@@ -1394,6 +1401,9 @@ TreeView.propTypes = {
 
   /** action to perform on click */
   clickAction: PropTypes.oneOf(CLICK_ACTIONS),
+
+  /** Indicates what action will be performed on a node which informs the correct aria-* properties to use on the node (aria-checked if using checkboxes, aria-selected if not). */
+  nodeAction: PropTypes.oneOf(NODE_ACTIONS),
 };
 
 export default TreeView;

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -252,8 +252,25 @@ export const getAriaSelected = ({
   isSelected: boolean;
   isDisabled: boolean;
   multiSelect: boolean;
-}) => {
+}): boolean | undefined => {
   if (isDisabled) return undefined;
+  if (multiSelect) return isSelected;
+  return isSelected ? true : undefined;
+};
+
+export const getAriaChecked = ({
+  isSelected,
+  isDisabled,
+  isHalfSelected,
+  multiSelect,
+}: {
+  isSelected: boolean;
+  isDisabled: boolean;
+  isHalfSelected: boolean;
+  multiSelect: boolean;
+}): boolean | undefined | "mixed" => {
+  if (isDisabled) return undefined;
+  if (isHalfSelected) return "mixed";
   if (multiSelect) return isSelected;
   return isSelected ? true : undefined;
 };

--- a/src/__tests__/CheckboxTree.test.tsx
+++ b/src/__tests__/CheckboxTree.test.tsx
@@ -59,6 +59,7 @@ function MultiSelectCheckbox() {
           propagateSelect
           propagateSelectUpwards
           togglableSelect
+          nodeAction="check"
           nodeRenderer={({
             element,
             getNodeProps,
@@ -92,11 +93,11 @@ test("Shift + Up / Down Arrow", () => {
   fireEvent.keyDown(nodes[0], { key: "ArrowDown", shiftKey: true });
 
   expect(document.activeElement).toEqual(nodes[1]);
-  expect(nodes[1]).toHaveAttribute("aria-selected", "true");
+  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
 
   fireEvent.keyDown(nodes[0], { key: "ArrowUp", shiftKey: true });
   expect(document.activeElement).toEqual(nodes[0]);
-  expect(nodes[0]).toHaveAttribute("aria-selected", "true");
+  expect(nodes[0]).toHaveAttribute("aria-checked", "true");
 });
 
 test("Shift + Up / Down Arrow", () => {
@@ -107,11 +108,11 @@ test("Shift + Up / Down Arrow", () => {
   fireEvent.keyDown(nodes[0], { key: "ArrowDown", shiftKey: true });
 
   expect(document.activeElement).toEqual(nodes[1]);
-  expect(nodes[1]).toHaveAttribute("aria-selected", "true");
+  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
 
   fireEvent.keyDown(nodes[0], { key: "ArrowUp", shiftKey: true });
   expect(document.activeElement).toEqual(nodes[0]);
-  expect(nodes[0]).toHaveAttribute("aria-selected", "true");
+  expect(nodes[0]).toHaveAttribute("aria-checked", "true");
 });
 
 test("propagateselect selects all child nodes", () => {
@@ -127,5 +128,29 @@ test("propagateselect selects all child nodes", () => {
   const childNodes = container.querySelectorAll(
     '[role="treeitem"][aria-level="2"]'
   );
-  childNodes.forEach((x) => expect(x).toHaveAttribute("aria-selected", "true"));
+  childNodes.forEach((x) => expect(x).toHaveAttribute("aria-checked", "true"));
+});
+
+test("expect when nodeAction='check', aria-multiselectable is not set and aria-checked is set", () => {
+  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const treeNodes = queryAllByRole("tree");
+  expect(treeNodes[0]).not.toHaveAttribute("aria-multiselectable");
+
+  const nodes = queryAllByRole("treeitem");
+  nodes.forEach((x) => expect(x).toHaveAttribute("aria-checked"));
+});
+
+test("expect when nodeAction='check', parent node indeterminate's state is set when a children node is checked ", () => {
+  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const nodes = queryAllByRole("treeitem");
+  nodes[0].focus();
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the first element with role["treeitem"]), but did not.`
+    );
+
+  nodes[0].focus();
+  fireEvent.keyDown(nodes[0], { key: "ArrowRight" });
+  fireEvent.keyDown(nodes[0], { key: "ArrowDown", shiftKey: true });
+  expect(nodes[0]).toHaveAttribute("aria-checked", "mixed");
 });

--- a/src/__tests__/DirectoryTree.test.tsx
+++ b/src/__tests__/DirectoryTree.test.tsx
@@ -322,3 +322,18 @@ test("Single character typeahead", () => {
   fireEvent.keyDown(nodes[0], { key: "s" });
   expect(document.activeElement).toEqual(getByText("src").parentElement);
 });
+
+test("expect aria-selected and aria-multiselectable='false' is set when nodeAction undefined", () => {
+  const { queryAllByRole } = render(<DirectoryTreeView />);
+  const treeNodes = queryAllByRole("tree");
+  expect(treeNodes[0]).toHaveAttribute("aria-multiselectable", "false");
+
+  const nodes = queryAllByRole("treeitem");
+  nodes[0].focus();
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the first element with role["treeitem"]), but did not.`
+    );
+  fireEvent.keyDown(document.activeElement, { key: "Enter" });
+  expect(nodes[0]).toHaveAttribute("aria-selected", "true");
+});

--- a/src/__tests__/MultiSelectDirectoryTree.test.tsx
+++ b/src/__tests__/MultiSelectDirectoryTree.test.tsx
@@ -77,3 +77,20 @@ test("Ctrl+A selects all nodes", () => {
   fireEvent.keyDown(document.activeElement, { key: "a", ctrlKey: true });
   nodes.forEach((x) => expect(x).toHaveAttribute("aria-selected", "true"));
 });
+
+test("expect aria-select and aria-multiselectable='true' is set when nodeAction undefined", () => {
+  const { queryAllByRole } = render(
+    <DirectoryTreeView defaultExpandedIds={data.map((x) => x.id)} />
+  );
+  const treeNodes = queryAllByRole("tree");
+  expect(treeNodes[0]).toHaveAttribute("aria-multiselectable", "true");
+
+  const nodes = queryAllByRole("treeitem");
+  nodes[0].focus();
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the first element with role["treeitem"]), but did not.`
+    );
+  fireEvent.keyDown(document.activeElement, { key: "a", ctrlKey: true });
+  nodes.forEach((x) => expect(x).toHaveAttribute("aria-selected", "true"));
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import TreeView, {
   ClickActions,
   CLICK_ACTIONS,
   IBranchProps,
-  ILeafProps,
+  LeafProps,
   INode,
   INodeRendererProps,
   ITreeViewOnExpandProps,
@@ -25,7 +25,7 @@ export {
   INodeRendererProps,
   ClickActions,
   IBranchProps,
-  ILeafProps,
+  LeafProps,
   ITreeViewState,
 };
 export default TreeView;


### PR DESCRIPTION
Improve accessibility by providing an option for consumers to indicated whether the Treeview is using a checkbox.
To solve the issue in: #32 

The use of aria-checked successfully:
- handles the indeterminate state (using aria-checked="mixed"), reading "<node name and level> checkbox half checked".
- announces the selected state of a selected node when you navigate to it. (eg. "avocados checked one of five level two"). 
