### PR TITLE
Fix indeterminate state to be applied to all parents of selected child

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -473,6 +473,7 @@ const useTree = ({
         data,
         idsToUpdate,
         selectedIds,
+        halfSelectedIds,
         disabledIds
       );
       for (const id of every) {

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -140,6 +140,7 @@ export const propagateSelectChange = (
   data: INode[],
   ids: Set<number>,
   selectedIds: Set<number>,
+  halfSelectedIds: Set<number>,
   disabledIds: Set<number>
 ) => {
   const changes = {
@@ -162,7 +163,7 @@ export const propagateSelectChange = (
         (x) => !disabledIds.has(x)
       );
       if (enabledChildren.length === 0) break;
-      const some = enabledChildren.some((x) => selectedIds.has(x));
+      const some = enabledChildren.some((x) => selectedIds.has(x) || halfSelectedIds.has(x) || changes.some.has(x));
       if (!some) {
         changes.none.add(parent);
       } else {

--- a/src/__tests__/CheckboxTree.test.tsx
+++ b/src/__tests__/CheckboxTree.test.tsx
@@ -64,9 +64,10 @@ function MultiSelectCheckbox() {
             getNodeProps,
             handleSelect,
             handleExpand,
+            isHalfSelected,
           }) => {
             return (
-              <div {...getNodeProps({ onClick: handleExpand })}>
+              <div {...getNodeProps({ onClick: handleExpand })} className={`${isHalfSelected ? 'half-selected' : ''}`}>
                 <div
                   className="checkbox-icon"
                   onClick={(e) => {
@@ -128,6 +129,28 @@ test("propagateselect selects all child nodes", () => {
     '[role="treeitem"][aria-level="2"]'
   );
   childNodes.forEach((x) => expect(x).toHaveAttribute("aria-selected", "true"));
+});
+
+test("propagateselectupwards half-selects all parent nodes", () => {
+  const { queryAllByRole, container } = render(<MultiSelectCheckbox />);
+  const nodes = queryAllByRole("treeitem");
+  nodes[1].focus();
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+    );
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Drinks
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Drinks group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Apple Juice
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Chocolate
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Coffee
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }) //Tea group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Black Tea
+  fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+  const nodeLevel3Parents = container.querySelectorAll('.half-selected');
+  expect(nodeLevel3Parents.length).toBe(2);
 });
 
 test("should have the correct setsize and posinset values", async () => {


### PR DESCRIPTION
Improve utils method propagateSelectChange to be able to half-select all parents in tree structure.
To solve the issue in: https://github.com/lissitz/react-accessible-treeview/issues/34